### PR TITLE
Fix erroneous boolean logic

### DIFF
--- a/alinco/alinco.c
+++ b/alinco/alinco.c
@@ -818,7 +818,7 @@ int alinco_get_ptt(RIG *rig, vfo_t vfo, ptt_t *ptt)
 		if (retval != RIG_OK)
 			return retval;
 
-		if (ptt_len != 3 || ptt_len != 4) {
+		if (ptt_len != 3 && ptt_len != 4) {
 			rig_debug(RIG_DEBUG_ERR,"alinco_get_ptt: wrong answer %s, "
 							"len=%d\n", pttbuf, ptt_len);
 			return -RIG_ERJCTED;
@@ -852,7 +852,7 @@ int alinco_get_dcd(RIG *rig, vfo_t vfo, dcd_t *dcd)
 		if (retval != RIG_OK)
 			return retval;
 
-		if (dcd_len != 4 || dcd_len != 5) {
+		if (dcd_len != 4 && dcd_len != 5) {
 			rig_debug(RIG_DEBUG_ERR,"alinco_get_dcd: wrong answer %s, "
 							"len=%d\n", dcdbuf, dcd_len);
 			return -RIG_ERJCTED;

--- a/kenwood/kenwood.c
+++ b/kenwood/kenwood.c
@@ -3180,7 +3180,7 @@ DECLARE_PROBERIG_BACKEND(kenwood)
   /*
    * reply should be something like 'IDxxx;'
    */
-  if (id_len != 5 || id_len != 6) {
+  if (id_len != 5 && id_len != 6) {
     idbuf[7] = '\0';
     rig_debug(RIG_DEBUG_VERBOSE, "probe_kenwood: protocol error, "
           " expected %d, received %d: %s\n",

--- a/kenwood/ts2k.c
+++ b/kenwood/ts2k.c
@@ -1819,7 +1819,7 @@ rig_model_t probe_ts2k(port_t * port)
 	/*
 	 * reply should be something like 'IDxxx;'
 	 */
-	if (id_len != 5 || id_len != 6) {
+	if (id_len != 5 && id_len != 6) {
 		idbuf[7] = '\0';
 		rig_debug(RIG_DEBUG_VERBOSE,
 			  "probe_ts2k: protocol error,"

--- a/yaesu/yaesu.c
+++ b/yaesu/yaesu.c
@@ -163,7 +163,7 @@ DECLARE_PROBERIG_BACKEND(yaesu)
 	/*
 	 * reply should be [Flag1,Flag2,Flag3,ID1,ID2]
 	 */
-	if (id_len != 5 || id_len != 6) {
+	if (id_len != 5 && id_len != 6) {
 		idbuf[YAESU_CMD_LENGTH] = '\0';
 		rig_debug(RIG_DEBUG_WARN,"probe_yaesu: protocol error,"
 			" expected %d, received %d: %s\n", 6, id_len, idbuf);


### PR DESCRIPTION
It seems like || was used where && was intended here. Currently, the
conditions are always true, and there's no reason for them to be written
this way.

Found with Coccinelle.