### PR TITLE
added instructions how to compile on OSX

### DIFF
--- a/README.osx
+++ b/README.osx
@@ -1,0 +1,32 @@
+OSX Builds
+----------
+
+To compile Hamlib on OSX you have to install autoconf, automake and libtool.
+The easiest way to install them is via the brew packet manager.
+
+http://brew.sh
+
+Once brew is installed, execute
+
+$ brew install automake autoconf libtool
+
+Build
+-----
+
+Execute autogen.sh with the desired flags
+
+$ ./autogen.sh
+
+Then compile the hamlib files
+
+$ ./make
+
+Hint: "./make -jx" with x for the amount of CPU cores will speed up the
+compilation
+
+Install hamlib
+--------------
+
+Install the Hamlib libraries and executables
+
+$ sudo ./make install

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,6 +13,11 @@ LIBTOOLIZE=libtoolize
 AUTORECONF=autoreconf
 AUTOMAKE=automake
 
+# Check if we compile on OSX and resolve the name conflict with
+# Apple's tool for creating Mach-O dynamic libraries.
+
+case `uname` in Darwin*) LIBTOOLIZE=glibtoolize ;; esac
+
 # variables below this line should not need modification
 SRCDIR=`dirname "$0"`
 test -z "$SRCDIR" && SRCDIR=.


### PR DESCRIPTION
Hi,

I added a small instruction on how to compile Hamlib on OSX. I also slightly modified the ./autogen.sh file to resolve a name conflict of libtool on OSX.

73 Tobias
EA4/DH1TW