### PR TITLE
Changes for IC-7300 and IC-7200

### DIFF
--- a/icom/ic7200.c
+++ b/icom/ic7200.c
@@ -80,7 +80,9 @@ static const struct icom_priv_caps IC7200_priv_caps = {
 		0x76,	/* default address */
 		0,		/* 731 mode */
     0,    /* no XCHG */
-		ic7200_ts_sc_list
+		ic7200_ts_sc_list,
+		.civ_version = 1        /* new version of some commands, e.g. ic7200/7300 */
+
 };
 
 

--- a/icom/icom.h
+++ b/icom/icom.h
@@ -111,6 +111,7 @@ struct icom_priv_caps {
 						       tokens to bandwidth and
 						       mode */
 	int serial_full_duplex; /*!< Whether RXD&TXD are not tied together */
+	unsigned char civ_version; // default to 0, 1=IC7200,IC7300,etc differences
 };
 
 
@@ -121,6 +122,7 @@ struct icom_priv_data {
 	int no_1a_03_cmd;							/* rig doesn't tell IF widths */
 	int split_on;									/* record split state */
 	pltstate_t *pltstate;	/* only on optoscan */
+	unsigned char civ_version; /* 0=default, 1=new commands for IC7200,IC7300, etc */
 };
 
 extern const struct ts_sc_list r8500_ts_sc_list[];
@@ -183,6 +185,8 @@ int icom_vfo_op(RIG *rig, vfo_t vfo, vfo_op_t op);
 int icom_scan(RIG *rig, vfo_t vfo, scan_t scan, int ch);
 int icom_set_level(RIG *rig, vfo_t vfo, setting_t level, value_t val);
 int icom_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val);
+int icom_set_ext_level(RIG *rig, vfo_t vfo, token_t token, value_t val);
+int icom_get_ext_level(RIG *rig, vfo_t vfo, token_t token, value_t *val);
 int icom_set_func(RIG *rig, vfo_t vfo, setting_t func, int status);
 int icom_get_func(RIG *rig, vfo_t vfo, setting_t func, int *status);
 int icom_set_parm(RIG *rig, setting_t parm, value_t val);
@@ -194,6 +198,8 @@ int icom_get_powerstat(RIG *rig, powerstat_t *status);
 int icom_set_ant(RIG * rig, vfo_t vfo, ant_t ant);
 int icom_get_ant(RIG * rig, vfo_t vfo, ant_t *ant);
 int icom_decode_event(RIG *rig);
+int icom_power2mW(RIG * rig, unsigned int *mwpower, float power, freq_t freq, rmode_t mode);
+int icom_mW2power(RIG * rig, float *power, unsigned int mwpower, freq_t freq, rmode_t mode);
 int icom_send_morse (RIG * rig, vfo_t vfo, const char *msg);
 
 extern const struct confparams icom_cfg_params[];

--- a/icom/icom_defs.h
+++ b/icom/icom_defs.h
@@ -294,6 +294,7 @@
  */
 #define S_PWR_OFF	0x00
 #define S_PWR_ON	0x01
+#define S_PWR_STDBY	0x02
 
 /*
  * Transmit control (C_CTL_PTT) subcommands
@@ -324,8 +325,8 @@
 #define S_MEM_SATMEM        0x01    /* Satellite memory */
 #define S_MEM_VOXGAIN       0x02    /* VOX gain level (0=0%, 255=100%) */
 #define S_MEM_VOXDELAY      0x03    /* VOX delay (0=0.0 sec, 20=2.0 sec) */
+#define S_MEM1_VOXDELAY     0x05    /* VOX delay (0=0.0 sec, 20=2.0 sec) */
 #define S_MEM_ANTIVOX       0x04    /* anti VOX setting */
-#define S_MEM_ATTLEVEL      0x05    /* Attenuation level (0=0%, 255=100%) */
 #define S_MEM_RIT           0x06    /* RIT (0=off, 1=on, 2=sub dial) */
 #define S_MEM_SATMODE       0x07    /* Satellite mode (on/off) */
 #define S_MEM_BANDSCOPE     0x08    /* Simple bandscope (on/off) */
@@ -391,6 +392,7 @@
 #define TOK_RTTY_FLTR TOKEN_BACKEND(100)
 #define TOK_SSBBASS TOKEN_BACKEND(101)
 #define TOK_SQLCTRL TOKEN_BACKEND(102)
+#define TOK_LEVEL_MONITOR TOKEN_BACKEND(103)
 
 
 #endif /* _ICOM_DEFS_H */


### PR DESCRIPTION
Added civ_version for newer rigs to use the newer command structures e.g. IC7200, IC7300, see icom.c and ic7300.c
Added ic7300_set_xit
Added ic7300_set_rit
Added ic7300_get_rit
Added ic7300_get_func
Added ic7300_set_func
Added RIG_LEVEL_KEYSPD
Fixed RIG_LEVEL_VOXDELAY
Fixed RIG_FUNC_FAGC
Fixed RIG_FUNC_VOX
Fixed RIG_FUNC_BACKLIGHT
Fixed RIG_PARM_BEEP
Fixed RIG_PARM_TIME
Fixed RIG_OP_TUNE
Removed unused items