### PR TITLE
Buffer overflow in rigctl_parse and rotctl_parse

### DIFF
--- a/tests/rigctl_parse.c
+++ b/tests/rigctl_parse.c
@@ -121,7 +121,7 @@ static pthread_mutex_t rig_mutex = PTHREAD_MUTEX_INITIALIZER;
 #ifdef HAVE_LIBREADLINE
 static char *input_line = (char *)NULL;
 static char *result = (char *)NULL;
-static char *parsed_input[sizeof(char) * 5];
+static char *parsed_input[sizeof(char*) * 5];
 static const int have_rl = 1;
 
 #ifdef HAVE_READLINE_HISTORY
@@ -429,6 +429,7 @@ static int scanfc(FILE *fin, const char *format, void *p)
 			if (errno == EINTR)
 				continue;
 			rig_debug(RIG_DEBUG_ERR, "fscanf: %s\n", strerror(errno));
+			rig_debug(RIG_DEBUG_ERR, "fscanf: parsing '%s' with '%s'\n", p, format);
 		}
 		return ret;
 	} while(1);

--- a/tests/rotctl_parse.c
+++ b/tests/rotctl_parse.c
@@ -118,7 +118,7 @@ static pthread_mutex_t rot_mutex = PTHREAD_MUTEX_INITIALIZER;
 #ifdef HAVE_LIBREADLINE
 static char *input_line = (char *)NULL;
 static char *result = (char *)NULL;
-static char *parsed_input[sizeof(char) * 7];
+static char *parsed_input[sizeof(char*) * 7];
 static const int have_rl = 1;
 
 #ifdef HAVE_READLINE_HISTORY
@@ -331,6 +331,7 @@ static int scanfc(FILE *fin, const char *format, void *p)
 			if (errno == EINTR)
 				continue;
 			rig_debug(RIG_DEBUG_ERR, "fscanf: %s\n", strerror(errno));
+			rig_debug(RIG_DEBUG_ERR, "fscanf: parsing '%s' with '%s'\n", p, format);
 		}
 		return ret;
 	} while(1);


### PR DESCRIPTION
Fixed buffer overflow in rigctl_parse and rotctl_parse
Showed up when connecting rigctl to rigctld via network and would get an fscanf arg error.
rigctl was sending \dump_state which overflowed the incorrectly allocated parsed_input
Surprised this didn't bite anybody before.
Thanks to PY1ZB for reporting the problem and helping with debug.
Mike W9MDB