### PR TITLE
Fix DIG MODE for FT817-ND

### DIFF
--- a/yaesu/ft817.c
+++ b/yaesu/ft817.c
@@ -117,8 +117,7 @@ static const yaesu_cmd_set_t ncmd[] = {
 };
 
 enum ft817_digi {
-  FT817_DIGI_RTTY_L = 0,
-  FT817_DIGI_RTTY_U,
+  FT817_DIGI_RTTY = 0,
   FT817_DIGI_PSK_L,
   FT817_DIGI_PSK_U,
   FT817_DIGI_USER_L,
@@ -503,8 +502,7 @@ int ft817_get_mode(RIG *rig, vfo_t vfo, rmode_t *mode, pbwidth_t *width)
   case 0x0a:
     switch (p->fm_status[5])
       {
-      case FT817_DIGI_RTTY_L: *mode = RIG_MODE_RTTY; break;
-      case FT817_DIGI_RTTY_U: *mode = RIG_MODE_RTTYR; break;
+      case FT817_DIGI_RTTY: *mode = RIG_MODE_RTTYR; break;
       case FT817_DIGI_PSK_L: *mode = RIG_MODE_PKTLSB; break;
       case FT817_DIGI_PSK_U: *mode = RIG_MODE_PKTUSB; break;
       case FT817_DIGI_USER_L: *mode = RIG_MODE_PKTLSB; break;


### PR DESCRIPTION
The FT817-ND only has RTTY, PSK31-L, PSK31-U, USER-L, USER-U as
possible DIG MODEs. Before this fix, the modes read by Hamlib were completely wrong.

The RTTY mode in the FT871-ND is USB. I think that the corresponding Hamlib mode is RIG_MODE_RTTYR but I'm not certain if this is supposed to be USB or LSB.

This has been tested on an FT871-ND. The FT871 might be different.