### PR TITLE
fixed reading the rig's return value in newcat_get_tx_vfo

### DIFF
--- a/yaesu/newcat.c
+++ b/yaesu/newcat.c
@@ -3543,7 +3543,7 @@ int newcat_get_tx_vfo(RIG * rig, vfo_t * tx_vfo) {
         return err;
       }
 
-    c = priv->ret_data[strlen (priv->cmd_str)];
+    c = priv->ret_data[strlen (priv->cmd_str)-1];
     switch (c) {
         case '0':
             *tx_vfo = RIG_VFO_A;

--- a/yaesu/newcat.c
+++ b/yaesu/newcat.c
@@ -3526,7 +3526,6 @@ int newcat_set_tx_vfo(RIG * rig, vfo_t tx_vfo) {
 int newcat_get_tx_vfo(RIG * rig, vfo_t * tx_vfo) {
     struct newcat_priv_data *priv = (struct newcat_priv_data *)rig->state.priv;
     int err;
-    char c;
     vfo_t vfo_mode;
     char const * command = "FT";
 
@@ -3543,8 +3542,7 @@ int newcat_get_tx_vfo(RIG * rig, vfo_t * tx_vfo) {
         return err;
       }
 
-    c = priv->ret_data[strlen (priv->cmd_str)-1];
-    switch (c) {
+    switch (priv->ret_data[2]) {
         case '0':
             *tx_vfo = RIG_VFO_A;
             break;


### PR DESCRIPTION
In commit e476780 @g4wjs accidentally introduced a small bug while improving `newcat_get_tx_vfo`.

Assuming split is disabled:

priv->cmd_str = FT; (len 3)
priv->ret_data = FT0; (len 4)

`priv->ret_data[strlen (priv->cmd_str)]` returns ';' but should return '0'. Since reading from char* is zero based, we have to retrieve `priv->ret_data[strlen (priv->cmd_str)-1]` to get the expected `0`.

I checked the CAT Manuals of FTDX9000, FT950, FT450 and FTDX1200 and they all work with this patch.