### PR TITLE
New rotator model: SPID MD-01/02 in ROT2 mode

### DIFF
--- a/include/hamlib/rotlist.h
+++ b/include/hamlib/rotlist.h
@@ -206,10 +206,17 @@
  *  The SPID backend can be used with rotators that support the SPID
  *  protocol.
  */
+/*! \def ROT_MODEL_SPID_MD01_ROT2PROG \brief A macro that returns the
+ *  model number of the MD-01/02 (ROT2PROG protocol) backend.
+ *
+ *  The SPID backend can be used with rotators that support the SPID
+ *  protocol.
+ */
 #define ROT_SPID 9
 #define ROT_BACKEND_SPID "spid"
 #define ROT_MODEL_SPID_ROT2PROG ROT_MAKE_MODEL(ROT_SPID, 1)
 #define ROT_MODEL_SPID_ROT1PROG ROT_MAKE_MODEL(ROT_SPID, 2)
+#define ROT_MODEL_SPID_MD01_ROT2PROG ROT_MAKE_MODEL(ROT_SPID, 3)
 
 /*! \def ROT_MODEL_RC2800
  *  \brief A macro that returns the model number of the RC2800 backend.

--- a/spid/spid.h
+++ b/spid/spid.h
@@ -24,5 +24,6 @@
 
 extern const struct rot_caps spid_rot1prog_rot_caps;
 extern const struct rot_caps spid_rot2prog_rot_caps;
+extern const struct rot_caps spid_md01_rot2prog_rot_caps;
 
 #endif /* _ROT_SPID_H */


### PR DESCRIPTION
Add driver for SPID MD-01 and MD-02 in ROT2 mode. The MD-01 and MD-02 extend the command set from the original ROT2PROG and deviates slightly from the original protocol on the set_position command.

Tested on MD-01 firmware version 1.2507 (2017-05-09).