### PR TITLE
This enables netrigctld to trigger two different CAT commands

### DIFF
--- a/dummy/netrigctl.c
+++ b/dummy/netrigctl.c
@@ -32,6 +32,8 @@
 #include <errno.h>
 
 #include "hamlib/rig.h"
+#include "network.h"
+#include "serial.h"
 #include "iofunc.h"
 #include "misc.h"
 #include "num_stdio.h"
@@ -49,6 +51,13 @@
 static int netrigctl_transaction(RIG *rig, char *cmd, int len, char *buf)
 {
   int ret;
+
+  /* flush anything in the read buffer before command is sent */
+  if (rig->state.rigport.type.rig == RIG_PORT_NETWORK || rig->state.rigport.type.rig == RIG_PORT_UDP_NETWORK) {
+        network_flush(&rig->state.rigport);
+  } else {
+      serial_flush(&rig->state.rigport);
+  }
 
   ret = write_block(&rig->state.rigport, cmd, len);
   if (ret != RIG_OK)
@@ -1339,7 +1348,7 @@ const struct rig_caps netrigctl_caps = {
   .status =         RIG_STATUS_BETA,
   .rig_type =       RIG_TYPE_OTHER,
   .targetable_vfo = 	 0,
-  .ptt_type =       RIG_PTT_RIG,
+  .ptt_type =       RIG_PTT_RIG_MICDATA,
   .dcd_type =       RIG_DCD_RIG,
   .port_type =      RIG_PORT_NETWORK,
   .timeout = 2000,	/* enough for a network */


### PR DESCRIPTION
a) enable netrigctl to use two different CAT PTT commands on the real rig (ptt on mic, ptt on data).
    This also includes a change to rigctl_parse.c to map requests to a safe variant if the "real" rig
    either does not have this capability or is PTT-ed by DTR etc.

b) netrigctl: drain the input line before sending a new command to come back in-sync after a timeout. Necessary for fldigi because of a programming error there (fldigi does not read the default rig timeout for non-serial-line rigs).

c) small changes: guard against a possible seg-fault of hamlib (line 1256 of rigctl_parse.c contains an obvious typo).