### PR TITLE
Get rid of compiler warnings, fix Kenwood RF get_level

### DIFF
--- a/barrett/barrett.c
+++ b/barrett/barrett.c
@@ -109,7 +109,7 @@ const struct rig_caps barrett_caps = {
         },
         RIG_FRNG_END,
     },
-    .rx_range_list1 = {RIG_FRNG_END,},
+    .rx_range_list2 = {RIG_FRNG_END,},
     .tx_range_list1 = {RIG_FRNG_END,},
     .tx_range_list2 = {RIG_FRNG_END,},
     .tuning_steps =  { {BARRETT_MODES, 1}, {BARRETT_MODES, RIG_TS_ANY}, RIG_TS_END, },

--- a/kenwood/kenwood.c
+++ b/kenwood/kenwood.c
@@ -1894,7 +1894,14 @@ int kenwood_get_level(RIG *rig, vfo_t vfo, setting_t level, value_t *val)
     break;
 
   case RIG_LEVEL_RFPOWER:
-    return get_kenwood_level(rig, "PC", &val->f);
+    /*
+     * an answer "PC100" means 100 Watt
+     * which is val=1.0 on most rigs, but
+     * get_kenwood_level maps 0...255 onto 0.0 ... 1.0
+     */
+    ret = get_kenwood_level(rig, "PC", &val->f);
+    val->f = val->f * (255.0/100.0);
+    return ret;
 
   case RIG_LEVEL_AF:
     return get_kenwood_level(rig, "AG", &val->f);

--- a/kenwood/th.c
+++ b/kenwood/th.c
@@ -1941,7 +1941,7 @@ int th_set_channel(RIG *rig, const channel_t *chan)
 		retval = sprintf(membuf, "%s,%011"PRIll",%X,%d,%d,%d,%d,%d,%02d,%02d,%03d,%09"PRIll",%d%s",
 			req, (int64_t)chan->freq, step, shift, rev, tone,
 			ctcss, dcs, tonefq, ctcssfq, dcscode,
-			(int64_t)abs(chan->rptr_offs), mode, lockoutstr
+			(int64_t)labs((long)(chan->rptr_offs)), mode, lockoutstr
 			);
 	} else {
 
@@ -1949,7 +1949,7 @@ int th_set_channel(RIG *rig, const channel_t *chan)
 		retval = sprintf(membuf, "%s,%011"PRIll",%X,%d,%d,%d,%d,,%02d,,%02d,%09"PRIll"%s",
 			req, (int64_t)chan->freq, step, shift, rev, tone,
 			ctcss, tonefq, ctcssfq,
-			(int64_t)abs(chan->rptr_offs), lockoutstr
+			(int64_t)labs((long)(chan->rptr_offs)), lockoutstr
 			);
 	}
 

--- a/kenwood/thd72.c
+++ b/kenwood/thd72.c
@@ -301,7 +301,9 @@ int thd72_get_chan_all_cb (RIG * rig, chan_cb_t chan_cb, rig_ptr_t arg)
                 break;
 
             /* non-empty channel ? */
-            if (block_chan[0] != 0xff) {
+            // if (block_chan[0] != 0xff) {
+	    // since block_chan is *signed* char, this maps to -1
+            if (block_chan[0] != -1) {
 
                 memcpy(chan->channel_desc, block_chan, 8);
                 /* TODO: chop off trailing chars */

--- a/uniden/uniden_digital.c
+++ b/uniden/uniden_digital.c
@@ -57,12 +57,15 @@
  * Location" command.
  */
 
+#if 0
+// deactivated temporarily because uniden_id_string_list is nowhere used
 static const struct { rig_model_t model; const char *id; }
 uniden_id_string_list[] = {
 	{ RIG_MODEL_BCD396T,  "BCD396T" },
-	{ RIG_MODEL_BCD996T,  "BCD99tT" },
+	{ RIG_MODEL_BCD996T,  "BCD996T" },
 	{ RIG_MODEL_NONE, NULL },	/* end marker */
 };
+#endif
 
 /* EOM is not consistant with this BCD996T!
  * Some commands  return newline while others carriage return.


### PR DESCRIPTION
This fixes some issues just to get rid of compiler warnings. In kenwood/thd72.c, I converted
the code to what I *think* was meant. In the original version, (block_chan[0] != 0xff) always
was zero, since a signed char cannot have a value of 0xff.

For kenwood, it makes get_level and set_level consistent for RIG_LEVEL_RFPOWER.

