### PR TITLE
Changes to make microHam support compile under MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,8 @@ AC_CHECK_HEADERS([errno.h fcntl.h getopt.h limits.h locale.h malloc.h \
 netdb.h sgtty.h stddef.h termio.h termios.h values.h \
 arpa/inet.h dev/ppbus/ppbconf.hdev/ppbus/ppi.h \
 linux/hidraw.h linux/ioctl.h linux/parport.h linux/ppdev.h  netinet/in.h \
-sys/ioccom.h sys/ioctl.h sys/param.h sys/socket.h sys/stat.h sys/time.h])
+sys/ioccom.h sys/ioctl.h sys/param.h sys/socket.h sys/stat.h sys/time.h \
+sys/select.h glob.h ])
 
 dnl set host_os variable
 AC_CANONICAL_HOST
@@ -235,7 +236,8 @@ AC_SUBST([NET_LIBS])
 dnl Checks for library functions.
 AC_CHECK_FUNCS([cfmakeraw floor getpagesize getpagesize gettimeofday inet_ntoa \
 ioctl memchr memmove memset pow rint select setitimer setlocale sigaction signal \
-snprintf socket sqrt strchr strdup strerror strncasecmp strrchr strstr strtol])
+snprintf socket sqrt strchr strdup strerror strncasecmp strrchr strstr strtol \
+glob socketpair ])
 AC_FUNC_ALLOCA
 
 dnl AC_LIBOBJ replacement functions directory

--- a/src/iofunc.c
+++ b/src/iofunc.c
@@ -223,12 +223,7 @@ int HAMLIB_API port_close(hamlib_port_t *p, rig_port_t port_type)
 #if defined(WIN32) && !defined(HAVE_TERMIOS_H)
 #include "win32termios.h"
 
-/*
- * We need uh_radio_fd to determine wether to use win32_serial_read() etc.
- * or (simply) read().
- */
-#include "microham.h"
-
+extern int is_uh_radio_fd(int fd);
 
 /* On MinGW32/MSVC/.. the appropriate accessor must be used
  * depending on the port type, sigh.
@@ -244,7 +239,7 @@ static ssize_t port_read(hamlib_port_t *p, void *buf, size_t count)
      * Note that we always have RIG_PORT_SERIAL in the
      * microHam case.
      */
-    if (p->fd == uh_radio_fd) {
+    if (is_uh_radio_fd(p->fd)) {
         return read(p->fd, buf, count);
     }
 
@@ -277,7 +272,7 @@ static ssize_t port_write(hamlib_port_t *p, const void *buf, size_t count)
      * Note that we always have RIG_PORT_SERIAL in the
      * microHam case.
      */
-    if (p->fd == uh_radio_fd) {
+    if (is_uh_radio_fd(p->fd)) {
         return write(p->fd, buf, count);
     }
 
@@ -319,7 +314,7 @@ static int port_select(hamlib_port_t *p, int n, fd_set *readfds,
      * Note that we always have RIG_PORT_SERIAL in the
      * microHam case.
      */
-    if (p->fd == uh_radio_fd) {
+    if (is_uh_radio_fd(p->fd)) {
         return select(n, readfds, writefds, exceptfds, timeout);
     }
 

--- a/src/microham.h
+++ b/src/microham.h
@@ -1,12 +1,7 @@
 //
-// Support for microHam
+// declaration of functions implemented in microham.c
 //
-// Store the fd's of the sockets here. Then we can tell later on
-// whether we are working on a "real" serial interface or on a socket
 //
-
-int uh_ptt_fd   = -1;   // PUBLIC! must be visible in iofunc.c in WIN32 case
-int uh_radio_fd = -1;   // PUBLIC! must be visible in iofunc.c in WIN32 case
 
 extern int  uh_open_radio(int baud, int databits, int stopbits, int rtscts);
 extern int  uh_open_ptt();

--- a/src/serial.c
+++ b/src/serial.c
@@ -84,6 +84,24 @@
 
 #include "microham.h"
 
+static int uh_ptt_fd   = -1;
+static int uh_radio_fd = -1;
+
+int is_uh_radio_fd(int fd) {
+    /*
+     * This function simply returns TRUE if the argument
+     * matches uh_radio_fd and is >= 0
+     *
+     * This function is only used in the WIN32 case and implements
+     * access "from outside" to uh_radio_fd.
+     */
+     if (uh_radio_fd >= 0 && uh_radio_fd == fd) {
+         return 1;
+     } else {
+         return 0;
+     }
+}
+
 /**
  * \brief Open serial port using rig.state data
  * \param rp port data structure (must spec port id eg /dev/ttyS1)


### PR DESCRIPTION
I downloaded msys2 and mingw to a windows laptop and figured out what need to
be changed such that microham support will correctly compile there.
Basically, one has to guard against non-existent syscalls such as socketpair()
and non-existent include files such as >sys/select.h>.

I changed configure.ac to "look" for these.