### PR TITLE
Fix IC-7300 S-meter calibration table length

### DIFF
--- a/icom/ic7300.c
+++ b/icom/ic7300.c
@@ -65,7 +65,7 @@
 /*
  * FIXME: This is a guess real measures please!
  */
-#define IC7300_STR_CAL { 3, \
+#define IC7300_STR_CAL { 4, \
 	{ \
 		{   0, -54 }, \
 		{  10, -24 }, \


### PR DESCRIPTION
The S-meter calibration table length not correct, making it impossible to detect signal strength levels above S9.