### PR TITLE
dummy: Add an option to output static values for RIG_LEVEL_STRENGTH and RIG_LEVEL_RAWSTR for integration testing purposes

### DIFF
--- a/dummy/dummy.h
+++ b/dummy/dummy.h
@@ -26,7 +26,8 @@
 #include "token.h"
 
 /* backend conf */
-#define TOK_CFG_MAGICCONF  TOKEN_BACKEND(1)
+#define TOK_CFG_MAGICCONF    TOKEN_BACKEND(1)
+#define TOK_CFG_STATIC_DATA  TOKEN_BACKEND(2)
 
 
 /* ext_level's and ext_parm's tokens */


### PR DESCRIPTION
Add an option `static_data` to dummy rig to output static values for RIG_LEVEL_STRENGTH and RIG_LEVEL_RAWSTR. This is very useful for integration testing purposes. The default is still to randomize S-meter values for the dummy rig.

